### PR TITLE
Fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/biter777/processex
+module github.com/elliottcarlson/processex
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/elliottcarlson/processex
+module github.com/biter777/processex
 
 go 1.13

--- a/process-windows.go
+++ b/process-windows.go
@@ -8,11 +8,11 @@ import (
 	"golang.org/x/sys/windows"
 ) 
 
-func newProcessFromEntry(entry *windows.ProcessEntry32) *process {
+func newProcessFromEntry(entry *windows.ProcessEntry32) *ProcessEx {
 	if entry == nil {
 		return nil
 	}
-	return newProcess(getProcessName(entry), int(entry.ProcessID), int(entry.ParentProcessID))
+	return newProcessEx(getProcessName(entry), int(entry.ProcessID), int(entry.ParentProcessID))
 }
 
 // ------------------------------------------------------------------

--- a/windows.go
+++ b/windows.go
@@ -57,7 +57,7 @@ func (p *winProcesses) getProcesses() error {
 func (p *winProcesses) FindByName(name string) ([]*os.Process, []*ProcessEx, error) {
 	err := p.getProcesses()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	return p.find(name, 0)
 }
@@ -66,7 +66,7 @@ func (p *winProcesses) FindByName(name string) ([]*os.Process, []*ProcessEx, err
 func (p *winProcesses) FindByPID(pid int) ([]*os.Process, []*ProcessEx, error) {
 	err := p.getProcesses()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	return p.find("", pid)
 }
@@ -87,12 +87,12 @@ func (p *linuxProcesses) getProcesses() error {
 
 // FindByName - FindByName
 func (p *linuxProcesses) FindByName(name string) ([]*os.Process, []*ProcessEx, error) {
-	return nil, errors.New("not linux os")
+	return nil, nil, errors.New("not linux os")
 }
 
 // FindByPID - FindByPID
 func (p *linuxProcesses) FindByPID(int) ([]*os.Process, []*ProcessEx, error) {
-	return nil, errors.New("not linux os")
+	return nil, nil, errors.New("not linux os")
 }
 
 // ------------------------------------------------------------------


### PR DESCRIPTION
Was getting the following errors with the existing code:
```
/home/sublimnl/go/pkg/mod/github.com/biter777/processex@v0.0.0-20210102170504-01bb369eda71/process-windows.go:11:58: undefined: process
/home/sublimnl/go/pkg/mod/github.com/biter777/processex@v0.0.0-20210102170504-01bb369eda71/process-windows.go:15:9: undefined: newProcess
/home/sublimnl/go/pkg/mod/github.com/biter777/processex@v0.0.0-20210102170504-01bb369eda71/windows.go:60:15: not enough return values 
        have (nil, error)
        want ([]*os.Process, []*ProcessEx, error)
/home/sublimnl/go/pkg/mod/github.com/biter777/processex@v0.0.0-20210102170504-01bb369eda71/windows.go:69:15: not enough return values 
        have (nil, error)
        want ([]*os.Process, []*ProcessEx, error)
/home/sublimnl/go/pkg/mod/github.com/biter777/processex@v0.0.0-20210102170504-01bb369eda71/windows.go:90:14: not enough return values 
        have (nil, error)
        want ([]*os.Process, []*ProcessEx, error)
/home/sublimnl/go/pkg/mod/github.com/biter777/processex@v0.0.0-20210102170504-01bb369eda71/windows.go:95:14: not enough return values 
        have (nil, error)
        want ([]*os.Process, []*ProcessEx, error)
```

Updated windows.go to return the additional nil expected on the specified lines;
Fixed process-windows.go to use the correct newProcessEx and ProcessEx return type

Tested and working for me on Windows 10